### PR TITLE
Release 0.12.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,15 @@ The package can be installed by adding `membrane_mp4_plugin` to your list of dep
 ```elixir
 defp deps do
 [
-    {:membrane_mp4_plugin, "~> 0.11.0"}
+    {:membrane_mp4_plugin, "~> 0.12.0"}
 ]
 end
 ```
 
 ## Usage
 ### `Membrane.MP4.Muxer.ISOM`
-For an example of muxing streams to a regular MP4 file, refer to 
-[`examples/muxer_isom.exs`](examples/muxer_isom.exs).
+ISOM muxer requires a sink that can handle `Membrane.File.SeekEvent`, e.g. `Membrane.File.Sink`.
+For an example of muxing streams to a regular MP4 file, refer to [`examples/muxer_isom.exs`](examples/muxer_isom.exs).
 
 To run the example, you can use the following command:
  ```bash

--- a/lib/membrane_mp4/muxer/isom.ex
+++ b/lib/membrane_mp4/muxer/isom.ex
@@ -1,6 +1,11 @@
 defmodule Membrane.MP4.Muxer.ISOM do
   @moduledoc """
   Puts payloaded streams into an MPEG-4 container.
+
+  Due to the structure of MPEG-4 containers, the muxer has to be used along with
+  `Membrane.File.Sink` or any other sink that can handle `Membrane.File.SeekEvent`.
+  The event is used to fill in `mdat` box size after processing all incoming buffers
+  and, if `fast_start` is set to `true`, to insert `moov` box at the beginning of the file.
   """
   use Membrane.Filter
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Membrane.MP4.Plugin.MixProject do
   use Mix.Project
 
-  @version "0.11.0"
+  @version "0.12.0"
   @github_url "https://github.com/membraneframework/membrane_mp4_plugin"
 
   def project do


### PR DESCRIPTION
This release makes `ISOM.Muxer` use `Membrane.File.SeekEvent` to allow muxing incoming payloads as they arrive, without storing everything in memory until the end of stream. Using `ISOM.Muxer` is now restricted only to pipelines that end with a sink that can handle `SeekEvent`.