### PR TITLE
Calculate elapsed time from first DTS

### DIFF
--- a/lib/membrane_mp4/movie_fragment_box.ex
+++ b/lib/membrane_mp4/movie_fragment_box.ex
@@ -79,7 +79,7 @@ defmodule Membrane.MP4.MovieFragmentBox do
               tfdt: %{
                 children: [],
                 fields: %{
-                  base_media_decode_time: config.elapsed_time,
+                  base_media_decode_time: config.base_timestamp,
                   flags: 0,
                   version: 1
                 }

--- a/lib/membrane_mp4/muxer/cmaf.ex
+++ b/lib/membrane_mp4/muxer/cmaf.ex
@@ -438,10 +438,12 @@ defmodule Membrane.MP4.Muxer.CMAF do
   defp update_awaiting_caps(state, _pad), do: state
 
   defp maybe_init_elapsed_time(state, pad, sample) do
-    if is_nil(state.pad_to_track_data[pad].elapsed_time) do
-      put_in(state, [:pad_to_track_data, pad, :elapsed_time], sample.dts)
-    else
-      state
+    case state do
+      %{pad_to_track_data: %{^pad => %{elapsed_time: nil}}} ->
+        put_in(state, [:pad_to_track_data, pad, :elapsed_time], sample.dts)
+
+      _else ->
+        state
     end
   end
 end

--- a/lib/membrane_mp4/muxer/cmaf.ex
+++ b/lib/membrane_mp4/muxer/cmaf.ex
@@ -306,7 +306,6 @@ defmodule Membrane.MP4.Muxer.CMAF do
         %{timescale: timescale} = ctx.pads[pad].caps
         first_sample = hd(samples)
         last_sample = List.last(samples)
-        samples = Enum.to_list(samples)
 
         samples_table =
           samples

--- a/lib/membrane_mp4/muxer/cmaf/segment.ex
+++ b/lib/membrane_mp4/muxer/cmaf/segment.ex
@@ -5,7 +5,7 @@ defmodule Membrane.MP4.Muxer.CMAF.Segment do
   @spec serialize([
           %{
             sequence_number: integer,
-            elapsed_time: integer,
+            base_timestamp: integer,
             timescale: integer,
             duration: integer,
             samples_table: [%{sample_size: integer, sample_flags: integer}],
@@ -25,7 +25,7 @@ defmodule Membrane.MP4.Muxer.CMAF.Segment do
 
         sidx_config =
           config
-          |> Map.take([:id, :elapsed_time, :timescale, :duration])
+          |> Map.take([:id, :base_timestamp, :timescale, :duration])
           |> Map.put(:referenced_size, byte_size(moof) + byte_size(mdat))
 
         sidx = SegmentIndexBox.assemble(sidx_config) |> Container.serialize!()

--- a/lib/membrane_mp4/muxer/cmaf/segment_helper.ex
+++ b/lib/membrane_mp4/muxer/cmaf/segment_helper.ex
@@ -231,7 +231,9 @@ defmodule Membrane.MP4.Muxer.CMAF.Segment.Helper do
   end
 
   defp max_end_timestamp(state) do
-    Enum.map(state.pad_to_track_data, fn {_key, track_data} ->
+    state.pad_to_track_data
+    |> Enum.reject(fn {_key, track_data} -> is_nil(track_data.elapsed_time) end)
+    |> Enum.map(fn {_key, track_data} ->
       Ratio.to_float(track_data.elapsed_time)
     end)
     |> Enum.max()

--- a/lib/membrane_mp4/muxer/cmaf/segment_helper.ex
+++ b/lib/membrane_mp4/muxer/cmaf/segment_helper.ex
@@ -26,7 +26,7 @@ defmodule Membrane.MP4.Muxer.CMAF.Segment.Helper do
   end
 
   defp push_video_segment(state, queue, pad, sample) do
-    base_timestamp = max_end_timestamp(state)
+    base_timestamp = max_segment_base_timestamp(state)
 
     queue = SamplesQueue.push_until_target(queue, sample, base_timestamp)
 
@@ -38,7 +38,7 @@ defmodule Membrane.MP4.Muxer.CMAF.Segment.Helper do
   end
 
   defp push_audio_segment(state, queue, pad, sample) do
-    base_timestamp = max_end_timestamp(state)
+    base_timestamp = max_segment_base_timestamp(state)
 
     any_video_tracks? =
       Enum.any?(state.sample_queues, fn {_pad, queue} -> queue.track_with_keyframes? end)
@@ -75,7 +75,7 @@ defmodule Membrane.MP4.Muxer.CMAF.Segment.Helper do
     total_collected_durations =
       Map.fetch!(state.pad_to_track_data, pad).parts_duration + collected_duration
 
-    base_timestamp = max_end_timestamp(state)
+    base_timestamp = max_segment_base_timestamp(state)
 
     queue =
       if total_collected_durations < state.segment_duration_range.min do
@@ -110,7 +110,7 @@ defmodule Membrane.MP4.Muxer.CMAF.Segment.Helper do
 
   @spec take_all_samples_for(state_t(), Membrane.Time.t()) :: {:segment, segment_t(), state_t()}
   def take_all_samples_for(state, duration) do
-    end_timestamp = max_end_timestamp(state) + duration
+    end_timestamp = max_segment_base_timestamp(state) + duration
 
     {segment, state} =
       state.sample_queues
@@ -134,7 +134,7 @@ defmodule Membrane.MP4.Muxer.CMAF.Segment.Helper do
 
       {:no_segment, update_queue_for(pad, queue, state)}
     else
-      base_timestamp = max_end_timestamp(state)
+      base_timestamp = max_segment_base_timestamp(state)
 
       queue = SamplesQueue.plain_push_until_target(queue, sample, base_timestamp)
 
@@ -230,11 +230,11 @@ defmodule Membrane.MP4.Muxer.CMAF.Segment.Helper do
     end
   end
 
-  defp max_end_timestamp(state) do
+  defp max_segment_base_timestamp(state) do
     state.pad_to_track_data
-    |> Enum.reject(fn {_key, track_data} -> is_nil(track_data.elapsed_time) end)
+    |> Enum.reject(fn {_key, track_data} -> is_nil(track_data.segment_base_timestamp) end)
     |> Enum.map(fn {_key, track_data} ->
-      Ratio.to_float(track_data.elapsed_time)
+      Ratio.to_float(track_data.segment_base_timestamp)
     end)
     |> Enum.max()
   end

--- a/lib/membrane_mp4/muxer/cmaf/track_samples_queue.ex
+++ b/lib/membrane_mp4/muxer/cmaf/track_samples_queue.ex
@@ -8,7 +8,6 @@ defmodule Membrane.MP4.Muxer.CMAF.TrackSamplesQueue do
             collected_samples_duration: 0,
             duration_range: nil,
             target_samples: [],
-            to_collect_duration: 0,
             excess_samples: []
 
   @type t :: %__MODULE__{

--- a/lib/membrane_mp4/muxer/isom.ex
+++ b/lib/membrane_mp4/muxer/isom.ex
@@ -120,6 +120,11 @@ defmodule Membrane.MP4.Muxer.ISOM do
 
   @impl true
   def handle_process(Pad.ref(:input, pad_ref), buffer, _ctx, state) do
+    # In case DTS is not set, use PTS. This is the case for audio tracks or H264 originated
+    # from an RTP stream. ISO base media file format specification uses DTS for calculating
+    # decoding deltas, and so is the implementation of sample table in this plugin.
+    buffer = %Buffer{buffer | dts: Buffer.get_dts_or_pts(buffer)}
+
     {maybe_buffer, state} =
       state
       |> update_in([:pad_to_track, pad_ref], &Track.store_sample(&1, buffer))

--- a/lib/membrane_mp4/payloader/aac.ex
+++ b/lib/membrane_mp4/payloader/aac.ex
@@ -6,7 +6,6 @@ defmodule Membrane.MP4.Payloader.AAC do
   - Packaging/Encapsulation And Setup Data section of https://wiki.multimedia.cx/index.php/Understanding_AAC
   """
   use Membrane.Filter
-  alias Membrane.Buffer
 
   def_input_pad :input, demand_unit: :buffers, caps: {Membrane.AAC, encapsulation: :none}
 
@@ -39,9 +38,6 @@ defmodule Membrane.MP4.Payloader.AAC do
 
   @impl true
   def handle_process(:input, buffer, _ctx, state) do
-    # We need DTS to be set, as ISO base media file format specification uses DTS
-    # for calculating decoding deltas (and so is our implementation of sample table)
-    buffer = %Buffer{buffer | dts: Buffer.get_dts_or_pts(buffer)}
     {{:ok, buffer: {:output, buffer}}, state}
   end
 

--- a/lib/membrane_mp4/payloader/aac.ex
+++ b/lib/membrane_mp4/payloader/aac.ex
@@ -39,7 +39,8 @@ defmodule Membrane.MP4.Payloader.AAC do
 
   @impl true
   def handle_process(:input, buffer, _ctx, state) do
-    # we set DTS=PTS, as ISO base media file format specification uses DTS for calculating deltas
+    # We need DTS to be set, as ISO base media file format specification uses DTS
+    # for calculating decoding deltas (and so is our implementation of sample table)
     buffer = %Buffer{buffer | dts: Buffer.get_dts_or_pts(buffer)}
     {{:ok, buffer: {:output, buffer}}, state}
   end

--- a/lib/membrane_mp4/payloader/aac.ex
+++ b/lib/membrane_mp4/payloader/aac.ex
@@ -40,7 +40,7 @@ defmodule Membrane.MP4.Payloader.AAC do
   @impl true
   def handle_process(:input, buffer, _ctx, state) do
     # we set DTS=PTS, as ISO base media file format specification uses DTS for calculating deltas
-    buffer = %Buffer{buffer | dts: buffer.pts}
+    buffer = %Buffer{buffer | dts: Buffer.get_dts_or_pts(buffer)}
     {{:ok, buffer: {:output, buffer}}, state}
   end
 

--- a/lib/membrane_mp4/payloader/h264.ex
+++ b/lib/membrane_mp4/payloader/h264.ex
@@ -69,14 +69,7 @@ defmodule Membrane.MP4.Payloader.H264 do
       |> maybe_remove_parameter_nalus(state)
       |> Enum.map_join(&to_length_prefixed/1)
 
-    buffer = %Buffer{
-      buffer
-      | payload: payload,
-        metadata: metadata,
-        # In case dts is not set, use pts instead
-        # This is the case for H264 originated from eg. RTP Streams
-        dts: Buffer.get_dts_or_pts(buffer)
-    }
+    buffer = %Buffer{buffer | payload: payload, metadata: metadata}
 
     {{:ok, caps ++ [buffer: {:output, buffer}, redemand: :output]}, state}
   end

--- a/lib/membrane_mp4/payloader/opus.ex
+++ b/lib/membrane_mp4/payloader/opus.ex
@@ -4,8 +4,8 @@ defmodule Membrane.MP4.Payloader.Opus do
   """
   use Membrane.Filter
 
-  alias Membrane.{Buffer, Opus}
   alias Membrane.MP4.Payload
+  alias Membrane.Opus
 
   def_input_pad :input,
     availability: :always,
@@ -37,10 +37,7 @@ defmodule Membrane.MP4.Payloader.Opus do
   end
 
   @impl true
-  def handle_process(:input, %Buffer{} = buffer, _ctx, state) do
-    # We need DTS to be set, as ISO base media file format specification uses DTS
-    # for calculating decoding deltas (and so is our implementation of sample table)
-    buffer = %Buffer{buffer | dts: Buffer.get_dts_or_pts(buffer)}
+  def handle_process(:input, buffer, _ctx, state) do
     {{:ok, buffer: {:output, buffer}}, state}
   end
 end

--- a/lib/membrane_mp4/payloader/opus.ex
+++ b/lib/membrane_mp4/payloader/opus.ex
@@ -38,6 +38,8 @@ defmodule Membrane.MP4.Payloader.Opus do
 
   @impl true
   def handle_process(:input, %Buffer{} = buffer, _ctx, state) do
+    # We need DTS to be set, as ISO base media file format specification uses DTS
+    # for calculating decoding deltas (and so is our implementation of sample table)
     buffer = %Buffer{buffer | dts: Buffer.get_dts_or_pts(buffer)}
     {{:ok, buffer: {:output, buffer}}, state}
   end

--- a/lib/membrane_mp4/segment_index_box.ex
+++ b/lib/membrane_mp4/segment_index_box.ex
@@ -12,7 +12,7 @@ defmodule Membrane.MP4.SegmentIndexBox do
 
   @spec assemble(%{
           id: non_neg_integer(),
-          elapsed_time: non_neg_integer(),
+          base_timestamp: non_neg_integer(),
           referenced_size: non_neg_integer(),
           timescale: non_neg_integer(),
           duration: non_neg_integer()
@@ -22,7 +22,7 @@ defmodule Membrane.MP4.SegmentIndexBox do
       sidx: %{
         children: [],
         fields: %{
-          earliest_presentation_time: config.elapsed_time,
+          earliest_presentation_time: config.base_timestamp,
           first_offset: 0,
           flags: 0,
           reference_count: 1,

--- a/test/membrane_mp4/muxer/cmaf/cmaf_test.exs
+++ b/test/membrane_mp4/muxer/cmaf/cmaf_test.exs
@@ -36,7 +36,7 @@ defmodule Membrane.MP4.Muxer.CMAF.Segment.HelperTest do
       awaiting_caps: nil,
       segment_duration_range: SegmentDurationRange.new(100),
       pad_to_track_data: %{
-        a: %{elapsed_time: 0, parts_duration: 0}
+        a: %{segment_base_timestamp: 0, parts_duration: 0}
       },
       sample_queues: %{a: queue}
     }


### PR DESCRIPTION
This change makes CMAF muxer initialize track's `elapsed_time` with first `dts` instead of `0`. `elapsed_time` is used by `CMAF.Segment.Helper` to calculate `end_timestamp` when collecting samples for consequent segments. It does so by taking only the samples, that have `dts < elapsed_time + target_duration` (the rest of them is supposed to be used in the next segments).
This breaks when a track begins with `dts` larger than `target_duration`, as all its samples are always being accumulated for the next segment.