### PR TITLE
Delete h264 duplicated parameter sets

### DIFF
--- a/lib/membrane_mp4/payloader/h264.ex
+++ b/lib/membrane_mp4/payloader/h264.ex
@@ -51,8 +51,8 @@ defmodule Membrane.MP4.Payloader.H264 do
       |> Enum.take_while(&(&1.metadata.h264.type in [:sei, :sps, :pps, :aud]))
       |> Enum.map(&{&1.metadata.h264.type, &1.payload})
 
-    pps = Keyword.get_values(grouped_nalus, :pps)
-    sps = Keyword.get_values(grouped_nalus, :sps)
+    pps = Keyword.get_values(grouped_nalus, :pps) |> Enum.uniq()
+    sps = Keyword.get_values(grouped_nalus, :sps) |> Enum.uniq()
 
     {maybe_stream_format, state} =
       if (pps != [] and pps != state.pps) or (sps != [] and sps != state.sps) do


### PR DESCRIPTION
Running the following simple pipeline will raise an issue of `variable parameter sets`
```
defmodule MembranePlayground.Pipeline do
  @moduledoc false

  use Membrane.Pipeline

  @impl true
  def handle_init(_ctx, _options) do
    sps = <<...>>
    pps = <<...>>

    spec =  [
      child(:source, %Membrane.File.Source{location: "./input.h264"})
      |> child(:parser, %Membrane.H264.Parser{sps: sps, pps: pps})
      |> child(:payloader, Membrane.MP4.Payloader.H264)
      |> via_in(Pad.ref(:input, :H264))
      |> child(:muxer, Membrane.MP4.Muxer.ISOM)
      |> child(:sink, %Membrane.File.Sink{location: "./output.mp4"})
    ]

    {[spec: spec], %{}}
  end
end
```

The `sps` and `pps` provided to the Parser will be duplicated on the first IDR, but not on the subsequent ones. The muxer will conclude that the two stream formats send by the payloader are not the same.

*Not sure if this issue should be fixed here or on the `Parser`*