### PR TITLE
Omit stream format generation on PPS change in h264 payloader

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The package can be installed by adding `membrane_mp4_plugin` to your list of dep
 ```elixir
 defp deps do
   [
-    {:membrane_mp4_plugin, "~> 0.26.1"}
+    {:membrane_mp4_plugin, "~> 0.27.0"}
   ]
 end
 ```

--- a/lib/membrane_mp4/payloader/h264.ex
+++ b/lib/membrane_mp4/payloader/h264.ex
@@ -55,7 +55,7 @@ defmodule Membrane.MP4.Payloader.H264 do
     sps = Keyword.get_values(grouped_nalus, :sps)
 
     {maybe_stream_format, state} =
-      if (pps != [] and pps != state.pps) or (sps != [] and sps != state.sps) do
+      if sps != [] and sps != state.sps do
         {[
            stream_format:
              {:output,

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Membrane.MP4.Plugin.MixProject do
   use Mix.Project
 
-  @version "0.26.1"
+  @version "0.27.0"
   @github_url "https://github.com/membraneframework/membrane_mp4_plugin"
 
   def project do


### PR DESCRIPTION
It can happen that PPS values changes on each H264 frame, in such case we probably don't want to generate a new stream format as it can generate a lot of cascading changes (e.g. CMAF muxer trying to create segments after each such format).

Similar behaviour is already implemented in elixir's h264 parser.