### PR TITLE
Allow for non null terminated string as name. Add support for compact_size equal to 1 in atom header

### DIFF
--- a/lib/membrane_mp4/container/header.ex
+++ b/lib/membrane_mp4/container/header.ex
@@ -30,11 +30,16 @@ defmodule Membrane.MP4.Container.Header do
           rest::binary>>
       ) do
     {size, rest} =
-      if compact_size == 1 do
-        <<large_size::64, new_rest::binary>> = rest
-        {large_size, new_rest}
-      else
-        {compact_size, rest}
+      case compact_size do
+        0 ->
+          {@compact_size_size + @name_size + byte_size(rest), rest}
+
+        1 ->
+          <<large_size::64, new_rest::binary>> = rest
+          {large_size, new_rest}
+
+        size ->
+          {size, rest}
       end
 
     header_size =

--- a/lib/membrane_mp4/container/parse_helper.ex
+++ b/lib/membrane_mp4/container/parse_helper.ex
@@ -133,10 +133,13 @@ defmodule Membrane.MP4.Container.ParseHelper do
     end
   end
 
-  defp parse_field(data, {name, :str}, context) do
+  defp parse_field(data, {_name, :str}, context) do
     case String.split(data, "\0", parts: 2) do
-      [str, rest] -> {:ok, {str, rest}, context}
-      _unknown_format -> parse_field_error(data, name)
+      [str, rest] ->
+        {:ok, {str, rest}, context}
+
+      [str] ->
+        {:ok, {str, <<>>}, context}
     end
   end
 

--- a/lib/membrane_mp4/demuxer/isom.ex
+++ b/lib/membrane_mp4/demuxer/isom.ex
@@ -14,14 +14,13 @@ defmodule Membrane.MP4.Demuxer.ISOM do
   alias Membrane.MP4.Container
   alias Membrane.MP4.Demuxer.ISOM.SamplesInfo
 
-  def_input_pad(:input,
+  def_input_pad :input,
     accepted_format:
       %RemoteStream{type: :bytestream, content_format: content_format}
       when content_format in [nil, MP4],
     demand_unit: :buffers
-  )
 
-  def_output_pad(:output,
+  def_output_pad :output,
     accepted_format:
       any_of(
         %Membrane.AAC{config: {:esds, _esds}},
@@ -32,28 +31,25 @@ defmodule Membrane.MP4.Demuxer.ISOM do
         %Membrane.Opus{self_delimiting?: false}
       ),
     availability: :on_request
-  )
 
-  def_options(
-    optimize_for_non_fast_start?: [
-      default: false,
-      spec: boolean(),
-      description: """
-      When set to `true`, the demuxer is optimized for working with non-fast_start MP4
-      stream (that means - with a stream, in which the :moov box is put after the :mdat box)
-      You might consider setting that option to `true` if the following two conditions are met:
-      - you are processing large non-fast_start MP4 files
-      - the source of the stream is a "seekable source" - currently the only possible
-      option is to use a `Membrane.File.Source` with `seekable?: true` option.
+  def_options optimize_for_non_fast_start?: [
+                default: false,
+                spec: boolean(),
+                description: """
+                When set to `true`, the demuxer is optimized for working with non-fast_start MP4
+                stream (that means - with a stream, in which the :moov box is put after the :mdat box)
+                You might consider setting that option to `true` if the following two conditions are met:
+                - you are processing large non-fast_start MP4 files
+                - the source of the stream is a "seekable source" - currently the only possible
+                option is to use a `Membrane.File.Source` with `seekable?: true` option.
 
-      When set to `false`, no optimization will be performed, so in case of processing the
-      non-fast_start MP4 stream, the whole content of the :mdat box will be stored in
-      memory.
+                When set to `false`, no optimization will be performed, so in case of processing the
+                non-fast_start MP4 stream, the whole content of the :mdat box will be stored in
+                memory.
 
-      Defaults to `false`.
-      """
-    ]
-  )
+                Defaults to `false`.
+                """
+              ]
 
   @typedoc """
   Notification sent when the tracks are identified in the MP4.

--- a/lib/membrane_mp4/demuxer/isom.ex
+++ b/lib/membrane_mp4/demuxer/isom.ex
@@ -66,7 +66,6 @@ defmodule Membrane.MP4.Demuxer.ISOM do
           {:new_tracks, [{track_id :: integer(), content :: struct()}]}
 
   @header_boxes [:ftyp, :moov]
-  @default_header_size 8
 
   @impl true
   def handle_init(_ctx, options) do
@@ -82,7 +81,7 @@ defmodule Membrane.MP4.Demuxer.ISOM do
       boxes_size: 0,
       mdat_beginning: nil,
       mdat_size: nil,
-      mdat_header_size: @default_header_size
+      mdat_header_size: nil
     }
 
     {[], state}
@@ -202,8 +201,15 @@ defmodule Membrane.MP4.Demuxer.ISOM do
     }
 
     maybe_header = parse_header(rest)
-    mdat_header_size = if maybe_header, do: maybe_header.header_size, else: @default_header_size
-    state = %{state | mdat_header_size: mdat_header_size}
+
+    state =
+      if maybe_header,
+        do: %{
+          state
+          | mdat_size: maybe_header.content_size,
+            mdat_header_size: maybe_header.header_size
+        },
+        else: state
 
     update_fsm_state_ctx =
       if :mdat in Keyword.keys(state.boxes) or
@@ -211,10 +217,7 @@ defmodule Membrane.MP4.Demuxer.ISOM do
         :started_parsing_mdat
       end
 
-    state = update_fsm_state(state, update_fsm_state_ctx)
-    partial = if state.fsm_state in [:skip_mdat, :go_back_to_mdat], do: <<>>, else: rest
-
-    state = %{state | partial: partial}
+    state = update_fsm_state(state, update_fsm_state_ctx) |> set_partial(rest)
 
     cond do
       state.fsm_state == :mdat_reading ->
@@ -223,7 +226,7 @@ defmodule Membrane.MP4.Demuxer.ISOM do
       state.optimize_for_non_fast_start? ->
         state =
           if state.fsm_state == :skip_mdat,
-            do: %{state | mdat_beginning: state.boxes_size, mdat_size: maybe_header.content_size},
+            do: %{state | mdat_beginning: state.boxes_size},
             else: state
 
         handle_non_fast_start_optimization(state)
@@ -231,6 +234,11 @@ defmodule Membrane.MP4.Demuxer.ISOM do
       true ->
         {[demand: :input], state}
     end
+  end
+
+  defp set_partial(state, rest) do
+    partial = if state.fsm_state in [:skip_mdat, :go_back_to_mdat], do: <<>>, else: rest
+    %{state | partial: partial}
   end
 
   defp update_fsm_state(state, ctx \\ nil) do
@@ -297,17 +305,13 @@ defmodule Membrane.MP4.Demuxer.ISOM do
     fsm_state
   end
 
-  defp handle_non_fast_start_optimization(
-         %{fsm_state: :skip_mdat, mdat_header_size: mdat_header_size} = state
-       ) do
-    box_after_mdat_beginning = state.mdat_beginning + mdat_header_size + state.mdat_size
+  defp handle_non_fast_start_optimization(%{fsm_state: :skip_mdat} = state) do
+    box_after_mdat_beginning = state.mdat_beginning + state.mdat_header_size + state.mdat_size
     seek(state, box_after_mdat_beginning, :infinity, false)
   end
 
-  defp handle_non_fast_start_optimization(
-         %{fsm_state: :go_back_to_mdat, mdat_header_size: mdat_header_size} = state
-       ) do
-    seek(state, state.mdat_beginning, state.mdat_size + mdat_header_size, false)
+  defp handle_non_fast_start_optimization(%{fsm_state: :go_back_to_mdat} = state) do
+    seek(state, state.mdat_beginning, state.mdat_size + state.mdat_header_size, false)
   end
 
   defp handle_non_fast_start_optimization(state) do
@@ -343,12 +347,13 @@ defmodule Membrane.MP4.Demuxer.ISOM do
 
     # Parse the data we received so far (partial or the whole mdat box in a single buffer) and
     # either store or send the data (if all pads are connected)
+    mdat_header_size = state.mdat_header_size
 
     data =
       if Keyword.has_key?(state.boxes, :mdat) do
         state.boxes[:mdat].content
       else
-        <<_header::binary-size(state.mdat_header_size), content::binary>> = state.partial
+        <<_header::binary-size(mdat_header_size), content::binary>> = state.partial
         content
       end
 


### PR DESCRIPTION
TODO:
- [x] Add handling of a situation where `compact_size == 0` 
- [x] Make sure the ISOM demuxer still properly handles short files
- [x] Refactor the code (especially consider the fact that header size is no more constant)