### PR TITLE
Add optional track synchronization in cmaf muxer

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The package can be installed by adding `membrane_mp4_plugin` to your list of dep
 ```elixir
 defp deps do
   [
-    {:membrane_mp4_plugin, "~> 0.31.0"}
+    {:membrane_mp4_plugin, "~> 0.32.0"}
   ]
 end
 ```

--- a/lib/membrane_mp4/muxer/cmaf.ex
+++ b/lib/membrane_mp4/muxer/cmaf.ex
@@ -395,8 +395,10 @@ defmodule Membrane.MP4.Muxer.CMAF do
   end
 
   @impl true
-  def handle_event(Pad.ref(:input, _ref), event, _ctx, state) do
-    {[forward: event], state}
+  def handle_event(Pad.ref(:input, _ref) = pad, event, _ctx, state) do
+    output_pad = state.input_to_output_pad[pad]
+
+    {[event: {output_pad, event}], state}
   end
 
   @impl true

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Membrane.MP4.Plugin.MixProject do
   use Mix.Project
 
-  @version "0.31.0"
+  @version "0.32.0"
   @github_url "https://github.com/membraneframework/membrane_mp4_plugin"
 
   def project do

--- a/test/membrane_mp4/muxer/cmaf/integration_test.exs
+++ b/test/membrane_mp4/muxer/cmaf/integration_test.exs
@@ -4,10 +4,12 @@ defmodule Membrane.MP4.Muxer.CMAF.IntegrationTest do
   import Membrane.ChildrenSpec
   import Membrane.Testing.Assertions
 
+  require Membrane.Pad
+
   alias Membrane.MP4.BufferLimiter
   alias Membrane.MP4.Container
   alias Membrane.MP4.Muxer.CMAF.RequestMediaFinalizeSender
-  alias Membrane.{Testing, Time}
+  alias Membrane.{Pad, Testing, Time}
 
   # Fixtures used in CMAF tests below were generated using `membrane_http_adaptive_stream_plugin`
   # with `muxer_segment_duration` option set to `Membrane.Time.seconds(2)`.
@@ -63,7 +65,7 @@ defmodule Membrane.MP4.Muxer.CMAF.IntegrationTest do
       |> child(:audio_parser, %Membrane.AAC.Parser{out_encapsulation: :none, output_config: :esds}),
       child(:video_source, %Membrane.File.Source{location: "test/fixtures/in_video.h264"})
       |> child(:video_parser, %Membrane.H264.Parser{
-        generate_best_effort_timestamps: %{framerate: {30, 1}},
+        generate_best_effort_timestamps: %{framerate: {30, 1}, add_dts_offest: false},
         output_stream_structure: :avc1
       }),
       child(:cmaf, %Membrane.MP4.Muxer.CMAF{
@@ -88,11 +90,79 @@ defmodule Membrane.MP4.Muxer.CMAF.IntegrationTest do
     1..2
     |> Enum.map(fn i ->
       assert_sink_buffer(pipeline, :sink, buffer)
+
       assert_mp4_equal(buffer.payload, "muxed_audio_video/segment_#{i}.m4s")
     end)
 
     assert_end_of_stream(pipeline, :sink)
     refute_sink_buffer(pipeline, :sink, _buffer, 0)
+
+    :ok = Testing.Pipeline.terminate(pipeline)
+  end
+
+  test "synchronized audio and video" do
+    structure = [
+      child(:cmaf, %Membrane.MP4.Muxer.CMAF{
+        segment_min_duration: Time.seconds(2)
+      }),
+      child(:audio_source, %Membrane.File.Source{location: "test/fixtures/in_audio.aac"})
+      |> child(:audio_parser, %Membrane.AAC.Parser{out_encapsulation: :none, output_config: :esds}),
+      child(:video_source, %Membrane.File.Source{location: "test/fixtures/in_video.h264"})
+      |> child(:video_parser, %Membrane.H264.Parser{
+        generate_best_effort_timestamps: %{framerate: {30, 1}, add_dts_offset: true},
+        output_stream_structure: :avc1
+      }),
+      ###
+      get_child(:video_parser)
+      |> via_in(Pad.ref(:input, :video))
+      |> get_child(:cmaf),
+      get_child(:audio_parser)
+      |> via_in(Pad.ref(:input, :audio))
+      |> get_child(:cmaf),
+      ###
+      get_child(:cmaf)
+      |> via_out(:output)
+      |> child(:video_sink, Membrane.Testing.Sink),
+      get_child(:cmaf)
+      |> via_out(Pad.ref(:synced_output, :audio))
+      |> child(:audio_sink, Membrane.Testing.Sink)
+    ]
+
+    pipeline = Testing.Pipeline.start_link_supervised!(spec: structure)
+
+    assert_sink_stream_format(pipeline, :audio_sink, %Membrane.CMAF.Track{
+      header: header,
+      content_type: :audio
+    })
+
+    assert_mp4_equal(header, "ref_audio_header.mp4")
+
+    assert_sink_stream_format(pipeline, :video_sink, %Membrane.CMAF.Track{
+      header: header,
+      content_type: :video
+    })
+
+    assert_mp4_equal(header, "ref_video_header.mp4")
+
+    1..2
+    |> Enum.map(fn i ->
+      assert_sink_buffer(pipeline, :audio_sink, audio_buffer)
+
+      assert_sink_buffer(pipeline, :video_sink, video_buffer)
+
+      # NOTE: due to 'add_dts_offset' the video is moved back by 500ms
+      assert_in_delta audio_buffer.metadata.duration,
+                      video_buffer.metadata.duration,
+                      Membrane.Time.milliseconds(600)
+
+      assert_mp4_equal(video_buffer.payload, "ref_video_segment#{i}.m4s")
+    end)
+
+    assert_end_of_stream(pipeline, :audio_sink)
+    assert_end_of_stream(pipeline, :video_sink)
+
+    refute_sink_buffer(pipeline, :audio_sink, _buffer, 0)
+    refute_sink_buffer(pipeline, :video_sink, _buffer, 0)
 
     :ok = Testing.Pipeline.terminate(pipeline)
   end

--- a/test/membrane_mp4/muxer/cmaf/integration_test.exs
+++ b/test/membrane_mp4/muxer/cmaf/integration_test.exs
@@ -121,10 +121,10 @@ defmodule Membrane.MP4.Muxer.CMAF.IntegrationTest do
       |> get_child(:cmaf),
       ###
       get_child(:cmaf)
-      |> via_out(:output)
+      |> via_out(Pad.ref(:output, :video), options: [tracks: [:video]])
       |> child(:video_sink, Membrane.Testing.Sink),
       get_child(:cmaf)
-      |> via_out(Pad.ref(:synced_output, :audio))
+      |> via_out(Pad.ref(:output, :audio), options: [tracks: [:audio]])
       |> child(:audio_sink, Membrane.Testing.Sink)
     ]
 


### PR DESCRIPTION
# Introduction
This PR introduces a new mechanism to a CMAF muxer allowing to synchronize audio/video tracks but without muxing them together.

## Problem
Protocols such as HLS/DASH allow audio/video tracks to be served separately but this requires them to have the same segment boundaries.

With the previous muxer's implementation to serve 2 separate tracks one needed 2 separate muxer instances. This solution had a problem, fluctuating video stream could cause desynchronization with audio track (segments could be created faster/slower causing a sequence numbers mismatch) as the synchronization was done purely through a target segment duration (unlike when muxing together, where the video is taken into account when assembling audio segment part).

## Solution
This PR replaces the default static `:output` pad with a dynamic one and introduces a `:tracks` pad option that tells which input pads should be mixed together on the output. Specifying 2 different output pads will result in 2 separate tracks that should be synchronized with each other.
